### PR TITLE
Switch to client-side rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@fontsource/fira-mono": "^4.5.10",
         "@neoconfetti/svelte": "^1.0.0",
-        "@sveltejs/adapter-auto": "^3.0.0",
+        "@sveltejs/adapter-static": "^3.0.0",
         "@sveltejs/kit": "^2.0.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
         "autoprefixer": "^10.4.16",
@@ -793,14 +793,12 @@
         "win32"
       ]
     },
-    "node_modules/@sveltejs/adapter-auto": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.1.1.tgz",
-      "integrity": "sha512-6LeZft2Fo/4HfmLBi5CucMYmgRxgcETweQl/yQoZo/895K3S9YWYN4Sfm/IhwlIpbJp3QNvhKmwCHbsqQNYQpw==",
+    "node_modules/@sveltejs/adapter-static": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
+      "integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
       "dev": true,
-      "dependencies": {
-        "import-meta-resolve": "^4.0.0"
-      },
+      "license": "MIT",
       "peerDependencies": {
         "@sveltejs/kit": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@fontsource/fira-mono": "^4.5.10",
     "@neoconfetti/svelte": "^1.0.0",
-    "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/adapter-static": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "autoprefixer": "^10.4.16",

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,0 +1,2 @@
+export const ssr = false;
+export const csr = true;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,13 +1,12 @@
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
-import adapter from "@sveltejs/adapter-auto";
+import adapter from "@sveltejs/adapter-static";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-    // If your environment is not supported or you settled on a specific environment, switch out the adapter.
-    // See https://kit.svelte.dev/docs/adapters for more information about adapters.
-    adapter: adapter(),
+    // Generate a purely static site with client-side rendering only.
+    // The fallback option enables SPA mode by serving index.html for unknown routes.
+    adapter: adapter({ fallback: 'index.html' }),
   },
 
   preprocess: [vitePreprocess({})],


### PR DESCRIPTION
## Summary
- use `@sveltejs/adapter-static`
- generate SPA with fallback `index.html`
- disable server side rendering via root layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685141c960ec832bb431717d0813f30f